### PR TITLE
[fix] typos

### DIFF
--- a/end-to-end/ethernet.md
+++ b/end-to-end/ethernet.md
@@ -69,7 +69,7 @@ One major benefit of random access protocols is simplicity. Unlike the turn-base
 
 When the recipient gets a packet, it replies with an ack. If two nodes send data simultaneously, the collision causes their packets to be corrupted, so no ack is sent. If the sender doesn't see an ack, it waits some random amount of time and re-sends. Waiting some random amount of time, instead of re-sending immediately, helps us avoid collisions when the packets are resent.
 
-The naive random access protocol is ``rude'' because nodes start talking whenever they want, and deal with collisions afterwards. A more ``polite'' variant of this protocol is called **Carrier Sense Multiple Access (CSMA)**. Nodes listen to the shared medium first to see if anybody is speaking, and only start talking when it is quiet. Here, ``listen'' refers to sensing a signal on the wire.
+The naive random access protocol is "rude" because nodes start talking whenever they want, and deal with collisions afterwards. A more "polite" variant of this protocol is called **Carrier Sense Multiple Access (CSMA)**. Nodes listen to the shared medium first to see if anybody is speaking, and only start talking when it is quiet. Here, "listen" refers to sensing a signal on the wire.
 
 Note that CSMA does not help us avoid all collisions. If signals instantaneously propagated along the entire length of the wire, there would be no collisions in CSMA. However, propagation delay can introduce issues. Suppose node A on one end of the wire hears silence and starts transmitting. The signal might not have propagated to node B yet, on the other end of the wire. Node B hears silence and also starts transmitting, causing a collision.
 
@@ -111,7 +111,7 @@ One problem with sending messages over a shared media is: When we transmit the m
 
 At Layer 2, every computer has a **MAC address** (Media Access Control). MAC addresses are 48 bits long, and are usually written in hexadecimal with colons separating every 2 hex digits (8 bits), e.g. `f8:ff:c2:2b:36:16`. MAC addresses are sometimes called ether addresses or link addresses.
 
-MAC addresses are usually permanently hard-coded (``burned in'') on a device (e.g. the NIC in your computer). Most OSes will let you override the MAC address in software, but every device already comes with a MAC address installed. MAC addresses are allocated according to the manufacturer that creates the hardware. The first two bits are flags, then the next 22 bits identify the manufacturer, then the last 24 bits identify the specific machine within that manufacturer's address space.
+MAC addresses are usually permanently hard-coded ("burned in") on a device (e.g. the NIC in your computer). Most OSes will let you override the MAC address in software, but every device already comes with a MAC address installed. MAC addresses are allocated according to the manufacturer that creates the hardware. The first two bits are flags, then the next 22 bits identify the manufacturer, then the last 24 bits identify the specific machine within that manufacturer's address space.
 
 Why not just use IP addressing? Hosts on a link might want to exchange messages, without ever being connected to the Internet (i.e. they don't have an IP address at all).
 
@@ -154,7 +154,7 @@ If there are multiple links in a single local network, we'd have to ensure that 
 
 Multicast gets more complicated in a Layer 2 network with multiple links. Additional protocols are needed, though we won't discuss further.
 
-One example of multicast being useful on a LAN is Bonjour/mDNS, a protocol developed by Apple. In this protocol, all Apple devices (e.g. iPhone, iPad, Apple TV) are hard-coded to join a special group on the local network. If your iPhone wants to find nearby devices to play music (e.g. Apple TV, Apple speaker or HomePod or whatever they call it), the iPhone can multicast a message to the group, asking if anybody can play music. Devices in the group can also multicast responses, saying ``I am an Apple TV and I can play music.'' Interestingly, this protocol actually also uses DNS in the multicast group to send SRV records, which maps each machine to its capabilities.
+One example of multicast being useful on a LAN is Bonjour/mDNS, a protocol developed by Apple. In this protocol, all Apple devices (e.g. iPhone, iPad, Apple TV) are hard-coded to join a special group on the local network. If your iPhone wants to find nearby devices to play music (e.g. Apple TV, Apple speaker or HomePod or whatever they call it), the iPhone can multicast a message to the group, asking if anybody can play music. Devices in the group can also multicast responses, saying "I am an Apple TV and I can play music." Interestingly, this protocol actually also uses DNS in the multicast group to send SRV records, which maps each machine to its capabilities.
 
 Historical note: In the modern Internet, we've said that the terms "router" and "switch" are interchangeable. Now that we have the notion of a Layer 2 network, we could say that a switch only operates at Layers 1 and 2, while a router operates at Layers 1, 2, and 3.
 

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ nav_order: 0
 
 _By [Peyrin Kao](https://peyrin.github.io), based on lectures by [Sylvia Ratnasamy](https://www2.eecs.berkeley.edu/Faculty/Homepages/ratnasamy.html), [Rob Shakir](https://rob.sh/), and others._
 
-These are the course notes for [CS 168: Computer Security](https://cs168.io/) at [UC Berkeley](https://eecs.berkeley.edu/).
+These are the course notes for [CS 168: Introduction to the Internet](https://cs168.io/) at [UC Berkeley](https://eecs.berkeley.edu/).
 
 Here is the official course description:
 

--- a/intro/headers.md
+++ b/intro/headers.md
@@ -167,6 +167,6 @@ By contrast, at Layers 1 and 2, the router must speak the same protocol as the p
 
 <img width="900px" src="/assets/intro/1-19-layers-host-routers.png">
 
-In summary: Each router parses Layers 1 and 2, while the end hosts parse Layers 1 through 7.
+In summary: Each router parses Layers 1 through 3, while the end hosts parse Layers 1 through 7.
 
 <img width="900px" src="/assets/intro/1-30-packet-path.png">

--- a/routing/addressing.md
+++ b/routing/addressing.md
@@ -56,7 +56,7 @@ More generally, our addresses have two parts: a network ID,and a host ID. This a
 
 <img width="900px" src="/assets/routing/2-103-address-intuition4.png">
 
-Note that the forwarding table in R9 still needs entries for each individual host inside its own network (i.e. network 3).
+Note that the forwarding table in R9 still needs entries for each individual host inside its own network (i.e. network 2).
 
 Similarly, R4, an internal router with no connections to other networks, needs both entries for individual hosts inside network 3, and aggregated entries for other networks (e.g. 2.* has a next hop of R9). The scale of a forwarding table depends on the number of internal hosts in the same network, plus the number of external networks.
 

--- a/routing/addressing.md
+++ b/routing/addressing.md
@@ -148,7 +148,7 @@ We could write IP addresses as a 32-bit sequence of 1s and 0s, or as a single bi
 
 So far, we've been writing ranges of addresses as bits (e.g. all IPs starting with 1101). To write a range of addresses, we can use **slash notation**. We write the fixed prefix, then we write 0s for all remaining unfixed bits, and we convert the resulting 32-bit value into an dotted quad IP address. Then, after the slash, we write the number of fixed bits.
 
-For example, if the prefix is 11000000, we add zeros for all the unfixed bits to get 11000000 00000000 00000000 00000000. As a 32-bit address, this is 192.0.0.0. Then, because 24 bits were fixed, we write the range as 192.0.0.0/24.
+For example, if the prefix is 11000000, we add zeros for all the unfixed bits to get 11000000 00000000 00000000 00000000. As a 32-bit address, this is 192.0.0.0. Then, because 8 bits were fixed, we write the range as 192.0.0.0/8.
 
 To write an individual address as a range, we could write something like 192.168.1.1/32, which indicates that all 32 bits are fixed. Also, the default route *.* can be written as 0.0.0.0/0.
 

--- a/routing/link-state.md
+++ b/routing/link-state.md
@@ -44,7 +44,7 @@ One thing we have to be careful about is inconsistencies between routers.
 
 Remember, every router is computing the shortest paths independently, and deciding on a next hop accordingly. Each router only controls its own next hop, and cannot influence what the next hop will do. 
 
-For example, suppose R5 computes this shortest path to A, and decides to forward packets to R2. Then, R2 computes this shortest path to A, and decides to forward packets to R5. Both routers computed valid shortest paths, but their decisions resulted in a routing loop.
+For example, suppose R3 computes this shortest path to A, and decides to forward packets to R2. Then, R2 computes this shortest path to A, and decides to forward packets to R3. Both routers computed valid shortest paths, but their decisions resulted in a routing loop.
 
 To avoid this problem, we have to make sure that all routers are producing forwarding decisions that are compatible with each other. What are the requirements for all routers to produce compatible decisions?
 
@@ -67,9 +67,9 @@ To discover neighbors, every router sends a hello message to all of its neighbor
 
 <img width="600px" src="/assets/routing/2-091-hellos.png">
 
-For example, in this network, E sends to both of its neighbors: ``Hello, I'm E.'' Now, B knows that it's connected to E, and C also knows that it's connected to E. Similarly, B says hello to E, so now E knows about B. Likewise, C says hello to E, so E also knows about C.
+For example, in this network, R2 sends to both of its neighbors: "Hello, I'm R2." Now, R1 knows that it's connected to R2, and R3 also knows that it's connected to R2. Similarly, R1 says hello to R2, so now R2 knows about R1. Likewise, R3 says hello to R2, so R2 also knows about R3.
 
-As a result, everybody now knows who their immediate neighbors are. Note that B does not know about C, because B and C are not neighbors.
+As a result, everybody now knows who their immediate neighbors are. Note that R1 does not know about R3, because R1 and R3 are not neighbors.
 
 <img width="900px" src="/assets/routing/2-092-after-hellos.png">
 


### PR DESCRIPTION
- Headers: Routers parse L1-3, not L1-2
- Addressing: R9 is in Network 2, not 3
- Addressing: 8 bits are fixed, not 24
- Ethernet: Latex style quotes
- Homepage: Course title
- Link-state: Text and diagram reference same router numbers